### PR TITLE
Link to latest release binaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,17 +55,22 @@ layout: base
     </h2>
     <div class="mt-8 flex lg:flex-shrink-0 lg:mt-0">
       <div class="ml-3 inline-flex rounded-md shadow">
-        <a href="https://github.com/kyleconroy/sqlc/releases/download/v1.14.0/sqlc_1.14.0_linux_amd64.zip" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-indigo-600 bg-white hover:text-indigo-500 focus:outline-none focus:shadow-outline transition duration-150 ease-in-out">
+        <a href="https://github.com/kyleconroy/sqlc/releases/download/v1.17.0/sqlc_1.17.0_linux_amd64.zip" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-indigo-600 bg-white hover:text-indigo-500 focus:outline-none focus:shadow-outline transition duration-150 ease-in-out">
           Linux
         </a>
       </div>
       <div class="ml-3 inline-flex rounded-md shadow">
-        <a href="https://github.com/kyleconroy/sqlc/releases/download/v1.14.0/sqlc_1.14.0_darwin_amd64.zip" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-indigo-600 bg-white hover:text-indigo-500 focus:outline-none focus:shadow-outline transition duration-150 ease-in-out">
-          macOS
+        <a href="https://github.com/kyleconroy/sqlc/releases/download/v1.17.0/sqlc_1.17.0_darwin_amd64.zip" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-indigo-600 bg-white hover:text-indigo-500 focus:outline-none focus:shadow-outline transition duration-150 ease-in-out">
+          macOS (AMD64)
         </a>
       </div>
       <div class="ml-3 inline-flex rounded-md shadow">
-        <a href="https://github.com/kyleconroy/sqlc/releases/download/v1.14.0/sqlc_1.14.0_windows_amd64.zip" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-indigo-600 bg-white hover:text-indigo-500 focus:outline-none focus:shadow-outline transition duration-150 ease-in-out">
+        <a href="https://github.com/kyleconroy/sqlc/releases/download/v1.17.0/sqlc_1.17.0_darwin_arm64.zip" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-indigo-600 bg-white hover:text-indigo-500 focus:outline-none focus:shadow-outline transition duration-150 ease-in-out">
+          macOS (ARM64)
+        </a>
+      </div>
+      <div class="ml-3 inline-flex rounded-md shadow">
+        <a href="https://github.com/kyleconroy/sqlc/releases/download/v1.17.0/sqlc_1.17.0_windows_amd64.zip" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-indigo-600 bg-white hover:text-indigo-500 focus:outline-none focus:shadow-outline transition duration-150 ease-in-out">
           Windows
         </a>
       </div>


### PR DESCRIPTION
This change updates links from 1.14.0 to 1.17.0, and adds a link to the Mac ARM64 architecture file.

I expect it'll look like this:

> <img width="1502" alt="image" src="https://user-images.githubusercontent.com/19393950/219796827-7e53589f-e1b2-4663-8ed1-f266e2acc378.png">

Though, it occurs to me that maybe simply linking to https://github.com/kyleconroy/sqlc/releases is more future-proof.